### PR TITLE
Use y4m as the container format for raw video

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,17 +43,17 @@ $(OUT)/audio.raw: $(SOURCE)
 	$(eval GAIN := 0$(shell ffmpeg -i $^ -filter:a volumedetect -f null /dev/null 2>&1 | sed -n "s/.*max_volume: -\(.*\) dB/\1/p"))
 	$(FFMPEG) -i $^ -f u8 -acodec pcm_u8 -ar 9198 -filter:a "volume=$(GAIN)dB" $@ 
 
-$(OUT)/frames: $(OUT)/video.mp4
+$(OUT)/frames: $(OUT)/video.y4m
 	@echo $(TITLE)Extracting frames...$(TITLE_END)
 	-@rm -rf $@
 	mkdir -p $@
 	$(FFMPEG) -i $^ -coder "raw" $@/%05d.tga
 
-$(OUT)/video.mp4: $(SOURCE)
+$(OUT)/video.y4m: $(SOURCE)
 	@echo $(TITLE)Resizing video...$(TITLE_END)
-	$(FFMPEG) -i $^ -c:v rawvideo  -vf scale=-2:144 $@.tmp.mp4
-	$(FFMPEG) -i $@.tmp.mp4 -c:v rawvideo  -filter:v "crop=160:144" $@
-	rm $@.tmp.mp4
+	$(FFMPEG) -i $^ -vf scale=-2:144 $@.tmp.y4m
+	$(FFMPEG) -i $@.tmp.y4m -filter:v "crop=160:144" $@
+	rm $@.tmp.y4m
 	
 clean:
 	rm -rf output


### PR DESCRIPTION
On Linux (Ubuntu 18.04) with ffmpeg 4.1.3 I get the following error when compiling a video:

```
Resizing video...
ffmpeg -loglevel warning -stats -hide_banner -i video.mkv -c:v rawvideo  -vf scale=-2:144 output/
[...]
[mp4 @ 0x55eb35bdd380] Could not find tag for codec rawvideo in stream #0, codec not currently supported in container
Could not write header for output file #0 (incorrect codec parameters ?): Invalid argument                
Error initializing output stream 0:0 --                                                                   
[aac @ 0x55eb35b78440] 2 frames left in the queue on closing                                              
[...]                               
```

Apparently rawvideo is not supported for mp4. This PR uses y4m as a container format intead, which seems to work fine.

Note that I have not tested it on other platforms.

(Edit: This is in addition to #3)